### PR TITLE
어드민 회원 테이블 교체

### DIFF
--- a/src/main/java/com/studyproject/boardadminproject/domain/AdminAccount.java
+++ b/src/main/java/com/studyproject/boardadminproject/domain/AdminAccount.java
@@ -20,7 +20,7 @@ import java.util.Set;
     @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields{
+public class AdminAccount extends AuditingFields{
 
     @Id
     @Column(length = 50)
@@ -36,9 +36,9 @@ public class UserAccount extends AuditingFields{
     @Setter @Column(length = 100) private String nickname;
     @Setter private String memo;
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -49,12 +49,12 @@ public class UserAccount extends AuditingFields{
         this.modifiedBy = createdBy;
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
     }
 
     public void addRoleType(RoleType roleType) {
@@ -72,7 +72,7 @@ public class UserAccount extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
+        if (!(o instanceof AdminAccount that)) return false;
         return this.getUserId() != null && Objects.equals(this.getUserId(), that.getUserId());
     }
 

--- a/src/main/java/com/studyproject/boardadminproject/dto/AdminAccountDto.java
+++ b/src/main/java/com/studyproject/boardadminproject/dto/AdminAccountDto.java
@@ -1,0 +1,55 @@
+package com.studyproject.boardadminproject.dto;
+
+import com.studyproject.boardadminproject.domain.AdminAccount;
+import com.studyproject.boardadminproject.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/studyproject/boardadminproject/dto/UserAccountDto.java
+++ b/src/main/java/com/studyproject/boardadminproject/dto/UserAccountDto.java
@@ -1,6 +1,6 @@
 package com.studyproject.boardadminproject.dto;
 
-import com.studyproject.boardadminproject.domain.UserAccount;
+import com.studyproject.boardadminproject.domain.AdminAccount;
 import com.studyproject.boardadminproject.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -8,7 +8,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -19,37 +18,11 @@ public record UserAccountDto(
         String modifiedBy
 ) {
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes,  String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
-    }
-
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes,  String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 }

--- a/src/main/java/com/studyproject/boardadminproject/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/studyproject/boardadminproject/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.studyproject.boardadminproject.dto.security;
 
 import com.studyproject.boardadminproject.domain.constant.RoleType;
-import com.studyproject.boardadminproject.dto.UserAccountDto;
+import com.studyproject.boardadminproject.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -41,7 +41,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
             dto.userId(),
             dto.userPassword(),
@@ -52,8 +52,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
           username,
           password,
           authorities.stream()

--- a/src/main/java/com/studyproject/boardadminproject/repository/AdminAccountRepository.java
+++ b/src/main/java/com/studyproject/boardadminproject/repository/AdminAccountRepository.java
@@ -1,0 +1,8 @@
+package com.studyproject.boardadminproject.repository;
+
+import com.studyproject.boardadminproject.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+
+}

--- a/src/main/java/com/studyproject/boardadminproject/repository/UserAccountRepository.java
+++ b/src/main/java/com/studyproject/boardadminproject/repository/UserAccountRepository.java
@@ -1,8 +1,0 @@
-package com.studyproject.boardadminproject.repository;
-
-import com.studyproject.boardadminproject.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 -- user account
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by)
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by)
 values ('hyeon', '{noop}dummy', 'ADMIN', 'Hyeon', 'hyeon@mail.com', 'Hyeon', now(), 'hyeon', now(), 'hyeon'),
        ('soo', '{noop}dummy', 'MANAGER', 'soo', 'soo@mail.com', 'soo', now(), 'soo', now(), 'soo'),
        ('kim', '{noop}dummy', 'MANAGER,DEVELOPER', 'kim', 'kim@mail.com', 'kim', now(), 'kim', now(), 'kim'),

--- a/src/test/java/com/studyproject/boardadminproject/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/studyproject/boardadminproject/controller/ArticleCommentManagementControllerTest.java
@@ -106,7 +106,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "hyeonTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "hyeon-test@email.con",
                 "hyeon-test",

--- a/src/test/java/com/studyproject/boardadminproject/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/studyproject/boardadminproject/controller/ArticleManagementControllerTest.java
@@ -108,7 +108,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "hyeonTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "hyeon-test@email.con",
                 "hyeon-test",

--- a/src/test/java/com/studyproject/boardadminproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/studyproject/boardadminproject/repository/JpaRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.studyproject.boardadminproject.repository;
 
-import com.studyproject.boardadminproject.domain.UserAccount;
+import com.studyproject.boardadminproject.domain.AdminAccount;
 import com.studyproject.boardadminproject.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 select 테스트")
@@ -35,10 +35,10 @@ class JpaRepositoryTest {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         // Then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
 
@@ -48,15 +48,15 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenInserting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of(
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of(
                 "test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousCount + 1);
     }
 
@@ -64,13 +64,13 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("hyeon");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("hyeon");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
-        UserAccount updateAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updateAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updateAccount)
@@ -82,14 +82,14 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenDeleting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("hyeon");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("hyeon");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousCount - 1);
     }
 

--- a/src/test/java/com/studyproject/boardadminproject/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/studyproject/boardadminproject/service/ArticleCommentManagementServiceTest.java
@@ -161,7 +161,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "hyeonTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "hyeon-test@email.con",
                 "hyeon-test",

--- a/src/test/java/com/studyproject/boardadminproject/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/studyproject/boardadminproject/service/ArticleManagementServiceTest.java
@@ -168,7 +168,6 @@ class ArticleManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "hyeonTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "hyeon-test@email.con",
                     "hyeon-test",


### PR DESCRIPTION
`user_account` -> `admin_account`로 어드민 회원 테이블 변경.
통신하려는 게시판 서비스의 회원 도메인명과 이름이 겹치기 때문에 변경합니다.